### PR TITLE
modify_request_headers hook and prepend_body hook to modify proxy response.

### DIFF
--- a/lib/Perlbal/BackendHTTP.pm
+++ b/lib/Perlbal/BackendHTTP.pm
@@ -528,12 +528,17 @@ sub handle_response { # : void
     # as well as setup our HTTP version appropriately
     $client->setup_keepalive($thd);
 
+    my $svc = ref $self->{service} eq 'Perlbal::Service' ? $self->{service} : $client->{service};
+    $svc->run_hook('modify_response_headers', $self, $client);
+
     print "  writing response headers to client\n" if Perlbal::DEBUG >= 3;
     $client->write($thd->to_string_ref);
 
     print("  content_length=", (defined $self->{content_length} ? $self->{content_length} : "(undef)"),
           "  remain=",         (defined $self->{content_length_remain} ? $self->{content_length_remain} : "(undef)"), "\n")
         if Perlbal::DEBUG >= 3;
+
+    $svc->run_hook('prepend_body', $self, $client);
 
     if (defined $self->{content_length} && ! $self->{content_length_remain}) {
         print "  done.  detaching.\n" if Perlbal::DEBUG >= 3;

--- a/lib/Perlbal/BackendHTTP.pm
+++ b/lib/Perlbal/BackendHTTP.pm
@@ -528,16 +528,12 @@ sub handle_response { # : void
     # as well as setup our HTTP version appropriately
     $client->setup_keepalive($thd);
 
-    $self->{service}->run_hook('modify_response_headers', $self, $client);
-
     print "  writing response headers to client\n" if Perlbal::DEBUG >= 3;
     $client->write($thd->to_string_ref);
 
     print("  content_length=", (defined $self->{content_length} ? $self->{content_length} : "(undef)"),
           "  remain=",         (defined $self->{content_length_remain} ? $self->{content_length_remain} : "(undef)"), "\n")
         if Perlbal::DEBUG >= 3;
-
-    $self->{service}->run_hook('prepend_body', $self, $client);
 
     if (defined $self->{content_length} && ! $self->{content_length_remain}) {
         print "  done.  detaching.\n" if Perlbal::DEBUG >= 3;

--- a/lib/Perlbal/BackendHTTP.pm
+++ b/lib/Perlbal/BackendHTTP.pm
@@ -528,12 +528,16 @@ sub handle_response { # : void
     # as well as setup our HTTP version appropriately
     $client->setup_keepalive($thd);
 
+    $self->{service}->run_hook('modify_response_headers', $self, $client);
+
     print "  writing response headers to client\n" if Perlbal::DEBUG >= 3;
     $client->write($thd->to_string_ref);
 
     print("  content_length=", (defined $self->{content_length} ? $self->{content_length} : "(undef)"),
           "  remain=",         (defined $self->{content_length_remain} ? $self->{content_length_remain} : "(undef)"), "\n")
         if Perlbal::DEBUG >= 3;
+
+    $self->{service}->run_hook('prepend_body', $self, $client);
 
     if (defined $self->{content_length} && ! $self->{content_length_remain}) {
         print "  done.  detaching.\n" if Perlbal::DEBUG >= 3;


### PR DESCRIPTION
Hi,

I've written a patch to add modify_request_headers hook and prepend_body hook 
for the purpose of modifying proxy response.

I'd like to handle flv streaming like this.
http://lists.danga.com/pipermail/mogilefs/2007-April/000861.html

But I don't like to inject the code handling flv streaming to BackendHTTP.pm directly.
I'd like to handle flv streaming with a plugin.So I need those hooks.

Please review this.Thanks.
