### PR TITLE
Add 'DEFAULT' command

### DIFF
--- a/conf/perlbal.conf
+++ b/conf/perlbal.conf
@@ -5,6 +5,10 @@
 # and configuration syntax.
 #
 
+# set up some defaults for all services that we create
+DEFAULT persist_client  = on
+DEFAULT persist_backend = on
+DEFAULT verify_backend  = off
 
 # this service's nodes are configured via a pool object.  if you need
 # to change them, telnet on in to the management port and you and/or your
@@ -17,8 +21,9 @@ CREATE SERVICE balancer
   SET listen          = 0.0.0.0:80
   SET role            = reverse_proxy
   SET pool            = dynamic
-  SET persist_client  = on
-  SET persist_backend = on
+
+  # we know this set of backends supports verification, so override the
+  # default that we set above.
   SET verify_backend  = on
 ENABLE balancer
 

--- a/devtools/gendocs.pl
+++ b/devtools/gendocs.pl
@@ -21,9 +21,15 @@ print H <<HTML;
 <pre>SET &lt;service-name&gt; &lt;param&gt; = &lt;value&gt;
 SET &lt;param&gt; = &lt;value&gt;
 </pre>
-HTML
 
-print H "Note on types:  'bool' values can be set using one of 1, true, yes, on, 0, false, off, or no.  'size' values are in integer bytes, or an integer followed by 'b', 'k', or 'm' (case-insensitive) for bytes, KiB, or MiB.";
+<p>Note on types:  'bool' values can be set using one of 1, true, yes, on, 0, false, off, or no.
+'size' values are in integer bytes, or an integer followed by 'b', 'k', or 'm' (case-insensitive)
+for bytes, KiB, or MiB.</p>
+
+<p>Note that you can set defaults for all services you create by using the DEFAULT command:</p>
+
+<pre>DEFAULT &lt;param&gt; = &lt;value&gt;</pre>
+HTML
 
 foreach my $role ("*", "reverse_proxy", "web_server") {
     if ($role eq "*") {

--- a/doc/config-guide.txt
+++ b/doc/config-guide.txt
@@ -17,6 +17,9 @@ create service <name>              -- create a new service
 set [<service>] <param> = <value>  -- set a property on a service (see service-parameters.txt)
                                       service name is optional when service was just created.
 
+default param = value              -- set a default value for a service parameter, to be used
+                                      whenever you create a new service
+
 enable <service>                   -- enable a service (start listening)
 disable <service>                  -- disable a service (stops listening)
 

--- a/doc/service-parameters.txt
+++ b/doc/service-parameters.txt
@@ -9,6 +9,11 @@
    false, off, or no. 'size' values are in integer bytes, or an integer
    followed by 'b', 'k', or 'm' (case-insensitive) for bytes, KiB, or MiB.
 
+   Note that you can set defaults for all services you create by using the
+   DEFAULT command:
+
+ DEFAULT <param> = <value>
+
 For all services:
 
 +----------------------------------------------------------------------------------+
@@ -75,6 +80,9 @@ For all services:
 |                           |    |                     |service that maps onto     |
 |                           |    |                     |other services.            |
 |---------------------------+----+---------------------+---------------------------|
+|server_tokens              |bool|true                 |Whether to provide a       |
+|                           |    |                     |"Server" header.           |
+|---------------------------+----+---------------------+---------------------------|
 |                           |    |                     |Path to directory          |
 |ssl_ca_path                |    |                     |containing certificates for|
 |                           |    |                     |SSL.                       |
@@ -98,11 +106,6 @@ For all services:
 |                           |    |                     |where trusted means their  |
 |                           |    |                     |X-Forwarded-For/etc headers|
 |                           |    |                     |are not munged.            |
-|---------------------------+----+---------------------+---------------------------|
-|                           |    |                     |Whether to provide a       |
-|server_tokens              |bool|true                 |'Server' header in the     |
-|                           |    |                     |headers that are sent back |
-|                           |    |                     |to the user                |
 +----------------------------------------------------------------------------------+
 
 Only for 'reverse_proxy' services:

--- a/lib/Perlbal.pm
+++ b/lib/Perlbal.pm
@@ -1079,6 +1079,14 @@ sub MANAGE_pool {
     return $mc->ok;
 }
 
+sub MANAGE_default {
+    my $mc = shift->parse(qr/^default (\w+) ?= ?(.+)$/,
+                          "usage: DEFAULT <param> = <value>");
+
+    my ($key, $val) = $mc->args;
+    return Perlbal::Service::set_defaults($mc, $key => $val);
+}
+
 sub MANAGE_set {
     my $mc = shift->parse(qr/^set (?:(\w+)[\. ])?([\w\.]+) ?= ?(.+)$/,
                           "usage: SET [<service>] <param> = <value>");

--- a/lib/Perlbal/Service.pm
+++ b/lib/Perlbal/Service.pm
@@ -111,6 +111,9 @@ use fields (
 # hash; 'role' => coderef to instantiate a client for this role
 our %PluginRoles;
 
+# used by set_defaults
+our $defaults = {};
+
 our $tunables = {
 
     'role' => {
@@ -790,9 +793,22 @@ sub init {
     for my $param (keys %$tunables) {
         my $tun     = $tunables->{$param};
         next unless $tun->{check_role} eq "*" || $tun->{check_role} eq $self->{role};
-        next unless exists $tun->{default};
-        $self->set($param, $tun->{default});
+
+        if (exists $defaults->{$param}) {
+            $self->set($param, $defaults->{$param});
+        } elsif (exists $tun->{default}) {
+            $self->set($param, $tun->{default});
+        }
     }
+}
+
+# Service default setter
+sub set_defaults {
+    my ($mc, %args) = @_;
+    foreach my $key (keys %args) {
+        $defaults->{$key} = $args{$key};
+    }
+    return $mc->ok;
 }
 
 # Service


### PR DESCRIPTION
This command allows you to set defaults on the service objects you create.  Useful if you have many services and you set the same parameters on each of them.

Usage:

```
DEFAULT persist_client  = true
DEFAULT persist_backend = true
```

As with the rest of Perlbal configuration, this functions top down.  The defaults only apply to services created after the default is set.
