### PR TITLE
fixing ENV substitution

### DIFF
--- a/lib/Perlbal.pm
+++ b/lib/Perlbal.pm
@@ -266,13 +266,14 @@ sub run_manage_command {
     $cmd =~ s/\s+$//;
     $cmd =~ s/\s+/ /g;
 
-    my $orig = $cmd; # save original case for some commands
-    $cmd =~ s/^([^=]+)/lc $1/e; # lowercase everything up to an =
-    return 1 unless $cmd =~ /^\S/;
-
     # expand variables
+    my $orig = $cmd; # save original case for some commands
+
     $cmd =~ s/\$\{(.+?)\}/_expand_config_var($1)/eg;
     $cmd =~ s/\$(\w+)/$ENV{$1}/g;
+
+    $cmd =~ s/^([^=]+)/lc $1/e; # lowercase everything up to an =
+    return 1 unless $cmd =~ /^\S/;
 
     $out ||= sub {};
     $ctx ||= Perlbal::CommandContext->new;


### PR DESCRIPTION
Before ENV variables are substituted, we lowercase the config, making all the variables substitutions on lowercase keys which is counter intuitive as ENV variables are supposed to be uppercase.

without this patch, I'd have to write
   docroot = $home/docroot

instead of:

  docroot = $HOME/docroot

It might be a breaking change for people, but I doubt a lot of people depends on that feature in its current state.
