### PR TITLE
get the maximum age of queues across all Perlbals

### DIFF
--- a/contrib/perlbal-check
+++ b/contrib/perlbal-check
@@ -33,6 +33,7 @@ use IO::Socket::INET;
 use Getopt::Long;
 use Data::Dumper qw(Dumper);
 use YAML qw(LoadFile);
+use List::Util qw(max);
 
 $| = 1;
 
@@ -366,8 +367,8 @@ sub watch_queues {
                             $services{$1}->{$3}->{$2};
                     # Keep tabs on the longest service name.
                     $maxlen = length($1) if (length($1) > $maxlen);
-                    if ($3 eq 'age' && $4 > $services{$1}->{$3}->{$2}) {
-                        $services{$1}->{$3}->{$2} = $4;
+                    if ($3 eq 'age') {
+                        $services{$1}->{$3}->{$2} = max($services{$1}->{$3}->{$2}, $4);
                     } else {
                         $services{$1}->{$3}->{$2} += $4;
                     }


### PR DESCRIPTION
The current logic will iterate to find the maximum age, but if the age on the node it's inspecting is less, it'll add it to the current tally. :)
