### PR TITLE
Throw an error if non-existing service is used in a VHOST line

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -104,6 +104,7 @@ t/45-buffereduploads.t
 t/50-plugins.t
 t/52-chunked-upload.t
 t/60-child-httpd.t
+t/74-plugin-vhosts.t
 t/75-plugin-include.t
 t/76-plugin-redirect.t
 t/77-plugin-throttle.t

--- a/lib/Perlbal/Plugin/Vhosts.pm
+++ b/lib/Perlbal/Plugin/Vhosts.pm
@@ -131,7 +131,15 @@ sub vhost_selector {
         my ($match_on, $force) = @_;
 
         my $map_name = $maps->{$match_on};
-        my $svc = $map_name ? Perlbal->service($map_name) : undef;
+        my $svc;
+        if ($map_name) {
+            $svc = Perlbal->service($map_name);
+            if (!$svc) {
+                Perlbal::log("warning", "The service name '$map_name' does not exist (configured for the vhost match '$match_on')");
+                $cb->_simple_response(404, "Not Found (no configured vhost)");
+                return 1;
+            }
+        }
 
         return 0 unless $svc || $force;
 

--- a/t/74-plugin-vhosts.t
+++ b/t/74-plugin-vhosts.t
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+
+use strict;
+use Perlbal::Test;
+use Perlbal::Test::WebServer;
+use Perlbal::Test::WebClient;
+use Test::More 'no_plan';
+
+my $port = new_port();
+
+my $web_port = start_webserver();
+ok($web_port, 'webserver started');
+
+my $conf = qq{
+LOAD Vhosts
+
+CREATE POOL a
+    POOL a ADD 127.0.0.1:$web_port
+
+CREATE SERVICE ss
+    SET role = selector
+    SET listen = 127.0.0.1:$port
+    SET persist_client = 1
+    SET plugins = Vhosts
+    VHOST doesnotexist.example.com = doesnotexist
+    VHOST * = test
+ENABLE ss
+
+CREATE SERVICE test
+    SET role = reverse_proxy
+    SET pool = a
+ENABLE test
+};
+
+my $msock = start_server($conf);
+ok($msock, 'perlbal started');
+
+# make first web client
+my $wc = Perlbal::Test::WebClient->new;
+$wc->server("127.0.0.1:$port");
+$wc->http_version('1.0');
+$wc->keepalive(1);
+
+{
+    my $resp = $wc->request({ host => "example.com", }, "test");
+    ok($resp->is_success, "Got a successful response");
+}
+
+{
+    my $resp = $wc->request({ host => "doesnotexist.example.com", }, "test");
+    is($resp->code, 404, "Got a 404 for non-existing service");
+}
+
+1;


### PR DESCRIPTION
Currently it is possible to assign a non-existing service to a VHOST line, e.g.

```
VHOST example.org = does_not_exist
VHOST * = my_service
```

A request to example.org will be silently handled by my_service here. I think that Perlbal should complain instead. Unfortunately it does not seem to be possible to complain while the configuration is parsed, because the service definition can be done after the vhosts definition. But it is possible to complain when the non-existent service is about to be used.

Regards,
    Slaven
