### PR TITLE
Remove unsafe/useless 'use lib' from codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+MYMETA.json
+MYMETA.yml
+Makefile
+blib
+pm_to_blib
+Perlbal-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+branches:
+  except:
+    - /^issue\d+/
+    - /^gh\d+/
+language: perl
+matrix:
+   fast_finish: true
+#   allow_failures:
+#     - perl: "5.12"
+#     - perl: "5.10"
+env:
+  global:
+    - PERL_USE_UNSAFE_INC=0
+    - AUTHOR_TESTING=1
+    - AUTOMATED_TESTING=1
+    - RELEASE_TESTING=1
+perl:
+  - "5.28"
+  - "5.26"
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
+script:
+  - perl Makefile.PL && make test
+

--- a/devtools/gendocs.pl
+++ b/devtools/gendocs.pl
@@ -3,7 +3,6 @@
 
 use strict;
 use FindBin;
-use lib "$FindBin::Bin/../lib";
 use Perlbal;
 
 my $tunables = Perlbal::Service::autodoc_get_tunables();

--- a/perlbal
+++ b/perlbal
@@ -32,7 +32,6 @@ You can use and redistribute Perlbal under the same terms as Perl itself.
 
 use strict;
 use warnings;
-use lib 'lib';
 use Perlbal;
 
 my $opt_daemonize;

--- a/t/77-plugin-throttle.t
+++ b/t/77-plugin-throttle.t
@@ -1,8 +1,6 @@
 use strict;
 use warnings;
 
-use lib 't/lib';
-
 use IO::Select;
 use Perlbal::Test;
 use Perlbal::Test::WebClient;

--- a/t/78-plugin-xffextras.t
+++ b/t/78-plugin-xffextras.t
@@ -1,8 +1,6 @@
 use strict;
 use warnings;
 
-use lib 't/lib';
-
 use Perlbal::Test;
 use Perlbal::Test::WebClient;
 use Perlbal::Test::WebServer;


### PR DESCRIPTION
    Unit tests do not need to add 'use lib "lib"',
    running 'prove -l' will automatically add it for you.

    Concerning the two other scripts, it's unsafe to add 'lib'
    to @INC, as this could result from loading .pm files from
    any location. (depending from where the command is run and
    which user is running it).

    Once installed, it will use the default Perl @INC locations.
    For development purpose, adding a -Ilib is probably better.

    Using FindBin can be aceptable but also leaves a hole as the
    lib directory might belong to a different user in production.

Note: this commit sit on top of the travis changes so I can be sure I'm not braking unit tests